### PR TITLE
Fix None goal in next_step

### DIFF
--- a/domains.py
+++ b/domains.py
@@ -56,9 +56,11 @@ def expand_attack_or_move(s):
 
 def expand_consolidate_attack(s):
     """Plan to regroup then attack spotted enemies as a team."""
-    staging = compute_staging_position(s["sim"])
-    for u in s["sim"].friendly_units:
-        u.state["staging_position"] = staging
+    sim = s["sim"]
+    if getattr(sim, "staging_position", None) is None:
+        sim.staging_position = compute_staging_position(sim)
+    for u in sim.friendly_units:
+        u.state["staging_position"] = sim.staging_position
     return [
         ("MoveToStaging", None),
         "WaitForGroup",

--- a/simulation.py
+++ b/simulation.py
@@ -30,6 +30,9 @@ class Simulation:
         self.friendly_drone = Drone("friendly", "enemy")
         self.enemy_drone = Drone("enemy", "friendly")
 
+        # Shared rally point for consolidate maneuvers
+        self.staging_position = None
+
         self.river = river
         self.forest = forest
         self.forest_edge = forest_edge

--- a/units/friendly_units.py
+++ b/units/friendly_units.py
@@ -30,12 +30,17 @@ class FriendlyUnit:
         """Regenerate or preserve the current plan depending on context or threats."""
         mission = "SecureOutpostMission"
         if not force_replan and self.current_plan:
-            for enemy_name, enemy in self.sim.enemy_units_dict.items():
-                if self.can_attack(enemy):
-                    if self.current_plan[0][:2] != ("AttackEnemy", enemy_name):
-                        force_replan = True
-                        logger.info(f"{self.name} forcing replan due to attackable enemy {enemy_name}")
-                        break
+            first = self.current_plan[0]
+            first_task = first[0] if isinstance(first, tuple) else first
+            if first_task not in ("MoveToStaging", "WaitForGroup"):
+                for enemy_name, enemy in self.sim.enemy_units_dict.items():
+                    if self.can_attack(enemy):
+                        if self.current_plan[0][:2] != ("AttackEnemy", enemy_name):
+                            force_replan = True
+                            logger.info(
+                                f"{self.name} forcing replan due to attackable enemy {enemy_name}"
+                            )
+                            break
 
         if force_replan or not self.current_plan:
             combined = copy.deepcopy(self.state)
@@ -152,8 +157,13 @@ class FriendlyUnit:
         logger.info(f"{self.name} moving to staging area with {steps} steps")
 
         if "staging_position" not in self.state:
-            self.state["staging_position"] = compute_staging_position(self.sim)
-        staging = self.state["staging_position"]
+            if self.sim.staging_position is None:
+                self.sim.staging_position = compute_staging_position(self.sim)
+            self.state["staging_position"] = self.sim.staging_position
+        else:
+            if self.sim.staging_position is None:
+                self.sim.staging_position = self.state["staging_position"]
+        staging = self.sim.staging_position
         for _ in range(steps):
             old_pos = self.state["position"]
             if self.state["position"] == staging:
@@ -169,12 +179,15 @@ class FriendlyUnit:
     def _execute_wait_for_group(self):
         """Hold until all friendly units reach the staging area."""
         if "staging_position" not in self.state:
-            self.state["staging_position"] = compute_staging_position(self.sim)
-        staging = self.state["staging_position"]
+            if self.sim.staging_position is None:
+                self.sim.staging_position = compute_staging_position(self.sim)
+            self.state["staging_position"] = self.sim.staging_position
+        staging = self.sim.staging_position
         all_ready = all_units_at_position(self.sim.friendly_units, staging)
         if all_ready:
             logger.info(f"{self.name} group assembled, proceeding")
             self.current_plan.pop(0)
+            self.sim.staging_position = None
         else:
             logger.info(f"{self.name} waiting at staging for group")
 
@@ -197,9 +210,10 @@ class FriendlyUnit:
         if task_name == "Move" and task_arg == "outpost":
             return self.state["outpost_position"]
         if task_name == "MoveToStaging":
-            if "staging_position" not in self.state:
-                self.state["staging_position"] = compute_staging_position(self.sim)
-            return self.state["staging_position"]
+            if self.sim.staging_position is None:
+                self.sim.staging_position = compute_staging_position(self.sim)
+            self.state["staging_position"] = self.sim.staging_position
+            return self.sim.staging_position
         if task_name in ("Move", "AttackEnemy") and task_arg:
             return self.sim.friendly_drone.last_known.get(task_arg, self.state["position"])
         return self.state["position"]

--- a/utils.py
+++ b/utils.py
@@ -59,7 +59,14 @@ def astar(start, goal, enemy_units=None, unit="unknown"):
     return path
 
 def next_step(start, goal, enemy_units=None, unit="unknown"):
-    """Return the next grid step along the path to a goal using A*."""
+    """Return the next grid step along the path to a goal using A*.
+
+    If ``goal`` is ``None`` the unit will stay in place. This guards
+    against incomplete state initialization resulting in ``None`` being
+    passed as the target position.
+    """
+    if start is None or goal is None:
+        return start
     path = astar(start, goal, enemy_units, unit)
     return path[1] if len(path) >= 2 else start
 


### PR DESCRIPTION
## Summary
- avoid crashing when next_step is called with a `None` goal
- keep a shared rally point for consolidations so units agree on staging

## Testing
- `python -m py_compile utils.py units/friendly_units.py units/enemy_units.py domains.py htn_v3.py`


------
https://chatgpt.com/codex/tasks/task_e_68419352cbcc8330bd7878270c5eb93a