### PR TITLE
Enhance defensive positioning

### DIFF
--- a/plotter.py
+++ b/plotter.py
@@ -49,6 +49,7 @@ class SimulationPlotter:
         self.friendly_attack_indicators = {}
 
         self.staging_markers = {}  # New: staging position markers
+        self.defend_markers = {}   # Defensive position markers
 
         # Build the static background (terrain, grid, arrows, outpost, etc.)
         self._init_plot()
@@ -341,6 +342,22 @@ class SimulationPlotter:
                 elif marker:
                     marker.set_visible(False)
 
+                # update defend markers
+                defend = u.state.get("defend_position")
+                marker = self.defend_markers.get(name)
+                if defend and alive:
+                    dx, dy = defend
+                    dcx = dx * CELL_SIZE + CELL_SIZE / 2
+                    dcy = dy * CELL_SIZE + CELL_SIZE / 2
+                    if marker:
+                        marker.set_offsets((dcx, dcy))
+                        marker.set_visible(True)
+                    else:
+                        m = self.ax.scatter(dcx, dcy, marker="P", color="gray", s=70, zorder=3)
+                        self.defend_markers[name] = m
+                elif marker:
+                    marker.set_visible(False)
+
         # update enemies
         _update_group(self.sim.enemy_units,
                     self.enemy_markers, self.enemy_arrows,
@@ -446,7 +463,8 @@ class SimulationPlotter:
         name_text_dict   = self.enemy_name_texts   if group == 'enemy' else self.friendly_name_texts
         ring_dict        = self.enemy_attack_indicators if group == 'enemy' else self.friendly_attack_indicators
 
-        for d in [marker_dict, arrow_dict, text_dict, name_text_dict, ring_dict]:
+        for d in [marker_dict, arrow_dict, text_dict, name_text_dict, ring_dict,
+                 self.staging_markers, self.defend_markers]:
             art = d.pop(name, None)
             if art:
                 art.remove()


### PR DESCRIPTION
## Summary
- add `compute_defend_position` for enemies
- select defensive positions dynamically when planning
- visualize defensive positions on the map

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'EOF'
from ga_optimizer import _build_enemy_units
from unit_factory import make_friendly
from units.friendly_units import FriendlyTank
from state_templates import tank_state_template, enemy_tank_state_template
from domains import secure_outpost_domain
from simulation import Simulation
friendlies=[make_friendly('FriendlyTankGroup',FriendlyTank,tank_state_template,secure_outpost_domain,enemy_tank_state_template)]
enemies=_build_enemy_units()
sim=Simulation(friendlies,enemies,visualize=False)
print('initial enemy plan',enemies[0].current_plan)
sim.step()
print('after step enemy plan',enemies[0].current_plan)
EOF

------
https://chatgpt.com/codex/tasks/task_e_684c2780ebd88330ac5aa2dc5cc53a8a